### PR TITLE
Adding OSM (OpenStreetMap) webfilter

### DIFF
--- a/t-webfilter.mkiv
+++ b/t-webfilter.mkiv
@@ -75,6 +75,15 @@
 
 \defineexternalfigure[GoogleCharts][method=png,scale=4000]
 
+\definewebfilter
+  [OpenStreetMap]
+  [\c!prefix={http://parent.tile.openstreetmap.org/cgi-bin/export?},
+   \c!transform=ampersand,
+   \c!suffix=,
+   \c!figuresetup=OpenStreetMap,
+  ]
+
+\defineexternalfigure[OpenStreetMap][maxwidth=\textwidth,maxheight=\textheight]
 
 \definewebfilter
   [UML]


### PR DESCRIPTION
# Adding a webfilter for integrating OSM maps (png,jpeg,svg,pdf).
## Minimal example:

```
\usemodule[webfilter]
\enabledirectives[schemes.cleanmethod=md5]
\enabletrackers [thirddata.webfilter]

\starttext
\startOpenStreetMap
  bbox=4.045,51.708,4.212,51.771
  scale=43500
  format=pdf
\stopOpenStreetMap
\stoptext
```
## Parsing URL

http://parent.tile.openstreetmap.org/cgi-bin/export?bbox=4.045,51.708,4.212,51.771&amp;scale=435000&amp;format=png
