### PR TITLE
Linemacros

### DIFF
--- a/vim-README.md
+++ b/vim-README.md
@@ -130,11 +130,7 @@ defines three things:
 
 4. A macro
 
-<<<<<<< HEAD
         \processmarkdownbuffer[...]
-=======
-        \processRUBYbuffer[...]
->>>>>>> master
 
      The argument to the macro is the name of a buffer, which is written to an
      external file, processesd by `2context.vim` and the result is read back in

--- a/vim-README.md
+++ b/vim-README.md
@@ -73,6 +73,9 @@ on the ConTeXt wiki for detailed instructions.
 
 Usage
 -----
+Include the module
+
+    \usemodule[vim]
 
 Suppose you want to syntax highlight Ruby. In particular, you want
 
@@ -127,7 +130,11 @@ defines three things:
 
 4. A macro
 
+<<<<<<< HEAD
         \processmarkdownbuffer[...]
+=======
+        \processRUBYbuffer[...]
+>>>>>>> master
 
      The argument to the macro is the name of a buffer, which is written to an
      external file, processesd by `2context.vim` and the result is read back in


### PR DESCRIPTION
Hi as proposed on feature request #29 after some testing i hereby open the pullrequest formy suggestions on how to improve use of linemacros (`\someline`, `\startline` and `\stopline`).
- line macros are still to be used inside comments only
- escape parameter may be set to true be needent
- showlinetags parameter (currently only in vim script `2context.vim`) for additionally typesetting macros primarily for document debugging purpose
- comments which only contain line macros are hidden
  * line is typeset as emtpy if not containing anything than comment
  * inlinecomment is simply replaced by empty string (could be changed to single whitespace)

The only file changed so far for starting discussion is `2context.vim` all other files stay unchanged.
Currently default value for showlinetags is 1 for debugging purpose.

TODO:
-make showlinetags parameter available within context
-discuss possible improvements of suggested functionality
 
