### PR TITLE
Updated 2context vim to process line macros

### DIFF
--- a/t-vim.tex
+++ b/t-vim.tex
@@ -106,10 +106,21 @@
 
 % Mode to testing the dev version of 2context script.
 \doifmodeelse{vim-dev}
-  {\def\vimtyping@script_name{2context.vim}}
+  {
+     \def\vimtyping@script_name{2context.vim}
+     \def\vimtyping@script_runtime_extra{vim}
+  }
   {\doifmodeelse\s!mkiv
-      {\ctxlua{context.setvalue("vimtyping@script_name",resolvers.resolve("full:2context.vim"))}}
-      {\def\vimtyping@script_name{kpse:2context.vim}}}
+      {
+          \ctxlua{context.setvalue("vimtyping@script_name",resolvers.resolve("full:2context.vim"))}
+          \ctxlua{context.setvalue("vimtyping@script_runtime_extra",resolvers.resolve("full:vim"))}
+      }
+      {
+          \def\vimtyping@script_name{kpse:2context.vim}
+          \def\vimtyping@script_runtime_extra{kpse:vim}
+      }
+   }
+
 
 \def\vimtyping@filter_command
   {vim -u \vimrc_filename\space % read global config file
@@ -122,14 +133,16 @@
        -s % silent
        -C % set compatible
        -n % no swap file
-       -c "syntax manual" % don't load filetype detection
-       -c "set syntax=\externalfilterparameter\c!syntax" %
+       -c 'syntax manual \letterbar\space % don't load filetype detection
+           let \letterampersand runtimepath="\vimtyping@script_runtime_extra," . \letterampersand runtimepath \letterbar\space % include path to t-vim vim directory the syntax subdirectory of which hosts the vimtypingfilter.vim syntax file
+           let syntaxbase="\externalfilterparameter\c!syntax"' % pass syntaxname to vim/syntax/vimtypingfilter.vim syntax file for inclusion
+       -c "set syntax=vimtypingfilter" %
        -c "set tabstop=\externalfilterparameter\c!tab" %
        % vim only accepts 10 -c commands, so we combine a few let statements
        -c "let contextstartline=\externalfilterparameter\c!start \letterbar\space %
            let contextstopline=\externalfilterparameter\c!stop   \letterbar\space %
            let strip=\getvalue{\vimtyping@id-\c!strip-\externalfilterparameter\c!strip}" %
-       -c "let escapecomments=\getvalue{\vimtyping@id-\c!escape-\externalfilterparameter\c!escape}" %
+       -c "let escapecomments=\getvalue{\vimtyping@id-\c!escape-\externalfilterparameter\c!escape}"
        -c "let highlight=[\externalfilterparameter\c!highlight]" %
        \vimrc_extras\space
        -c "source \vimtyping@script_name" %
@@ -144,12 +157,14 @@
 \setvalue{\vimtyping@id-\c!escape-\v!on}{1}
 
 
+
 % Undocumented ... but useful if the user makes a mistake
 \setvalue{\vimtyping@id-\c!strip-\v!no}{0}
 \setvalue{\vimtyping@id-\c!strip-\v!yes}{1}
 
 \setvalue{\vimtyping@id-\c!escape-\v!no}{0}
 \setvalue{\vimtyping@id-\c!escape-\v!yes}{1}
+
 
 
 \setupvimtyping

--- a/tests/vim/33-btex-etex-global.tex
+++ b/tests/vim/33-btex-etex-global.tex
@@ -1,0 +1,16 @@
+\usemodule[vim]
+\definevimtyping[Python][syntax=python,tab=4,numbering=yes]
+\traceexternalfilters
+\starttext
+This is a litte linenumber test using /BTEX /ETEX markers.
+\startPython
+"""small test""" /BTEX \someline[ln:first_someline] /ETEX
+/BTEX \startline[ln:first_lineblock] /ETEX
+def funny_method()
+    print("I'm funny")
+/BTEX \stopline[ln:first_lineblock] /ETEX
+\stopPython
+
+If this works docstring should be on \inline[ln:first_someline] and
+\inlinePython{funny_method} should be defined between lines \inlinerange[ln:first_lineblock].
+\stoptext

--- a/tests/vim/34-btex-etex-comment.tex
+++ b/tests/vim/34-btex-etex-comment.tex
@@ -1,0 +1,19 @@
+
+\usemodule[vim]
+\definevimtyping[Python][syntax=python,tab=4,numbering=yes]
+\traceexternalfilters
+\starttext
+This is a more complex test using /BTEX /ETEX markers.
+\startPython
+"""small test""" # /BTEX \someline[ln:first_someline] /ETEX
+/BTEX \startline[ln:first_lineblock] /ETEX
+def funny_method(x,k)
+    print("I'm funny") # math formula inside comment and method /BTEX \m{\fraction{x^2}{k+1}} /ETEX
+    return x**2 / ( k + 1)  /BTEX \someline[ln:calculate_formula] /ETEX
+/BTEX \stopline[ln:first_lineblock] /ETEX
+\stopPython
+
+If this works docstring should be on \inline[ln:first_someline] and
+\inlinePython{funny_method} should be defined between lines \inlinerange[ln:first_lineblock].
+The comment contains a math formula typset by context and the following line \inline[ln:calculate_formula] returns its result
+\stoptext

--- a/vim/syntax/vimtypingfilter.vim
+++ b/vim/syntax/vimtypingfilter.vim
@@ -1,0 +1,20 @@
+"" include underlying syntax file as denoted by syntaxbase variable
+"" keep value of b:current_syntax variable
+execute "runtime! " . fnameescape("syntax/" . syntaxbase . ".vim")
+
+"" add a new syntax group called vimTypingTeXTags and allow it to be matched
+"" within other groups as well as on top
+
+"" TODO this is a rather broad matching guess
+"" some languages need to be setup more specific eg. HTML
+"" single them out by questing explicitly syntaxbase string defining
+"" vimTypeingTeXTags syntax group specifically for language instead of using
+"" below generic pattern
+"" TODO the below generic group-name pattern covering a big set of languages
+"" rather well. It is rather non specific global
+"" make more specific if necessary
+syntax region vimTypingTeXTags start="/BTEX" end="/ETEX" transparent containedin=\w*\([Cc]omment\|[Tt]odo\|[Ss]tatement\|[Mm]acro\|[Dd]efine\|[Pp]re[Cc]ondit\|[Tt]ypedef\|[Dd]ebug\|[Bb]lock\|[Rr]egion\|[Hh]eredoc\|[Ee]nvironment\|[Ee]xpression\|[Cc]ontext\|[Dd]ocument\|[Zz]onei\|[Bb]ody\|[Ss]kip\)\w* contains=NONE
+
+
+"" unless a highlighting group is needed too for transparent syntaxgroup 
+"" the above should do the trick


### PR DESCRIPTION
Hi as proposed on feature request #29 after some testing i hereby open the pullrequest formy suggestions on how to improve use of linemacros (\someline, \startline and \stopline).

    line macros are still to be used inside comments only
    escape parameter may be set to true be needent
    showlinetags parameter (currently only in vim script 2context.vim) for additionally typesetting macros primarily for document debugging purpose
    comments which only contain line macros are hidden
        line is typeset as emtpy if not containing anything than comment
        inlinecomment is simply replaced by empty string (could be changed to single whitespace)

The only file changed so far for starting discussion is 2context.vim all other files stay unchanged.
Currently default value for showlinetags is 1 for debugging purpose.

NOTE: fixes and replaces pullrequest #30 

TODO:
-make showlinetags parameter available within context
-discuss possible improvements of suggested functionality