### PR TITLE
First attempt to get BTEX .. ETEX working

### DIFF
--- a/2context.vim
+++ b/2context.vim
@@ -65,7 +65,24 @@ else
   let s:strip = 0
 endif
 
+" Find /BTEX .. /ETEX and store their lines
 let s:lines = []
+let s:btex  = {}
+if 1 " TODO: Create an interface
+  echo "Searching for /BTEX ... /ETEX"
+  for s:lnum in range(s:lstart, s:lstop)
+    let s:line  = getline(s:lnum)
+    let s:matches = matchlist(s:line,'\/BTEX\s*\(.\{-}\)\s*\/ETEX')
+    if len(s:matches) > 0 " line contains /BTEX.../ETEX
+       let s:btex[s:lnum] = s:matches[1]
+    endif
+  endfor
+endif
+echo s:btex
+
+" Remove all /BTEX ... /ETEX from original file
+s/\/BTEX.\{-}\/ETEX//e
+
 
 " Loop over all lines in the original text.
 let s:buffer_lnum = 1
@@ -133,6 +150,11 @@ while s:lnum <= s:lstop
 " Highlight line, if needed.
   if (index(highlight, s:lnum) != -1)
     let s:new = '\HGL{' . s:new . '}'
+  endif
+
+  " Add BTEX ... ETEX if available
+  if has_key(s:btex, s:lnum)
+    let s:new = s:new . s:btex[s:lnum]
   endif
 
   " Add begin and end line markers 

--- a/t-vim.tex
+++ b/t-vim.tex
@@ -133,7 +133,7 @@
        -c "let highlight=[\externalfilterparameter\c!highlight]" %
        \vimrc_extras\space
        -c "source \vimtyping@script_name" %
-       -c "qa" %
+       -c "qa!" %
        \externalfilterinputfile\space
        \externalfilteroutputfile}
 

--- a/tests/vim/41-btex.tex
+++ b/tests/vim/41-btex.tex
@@ -1,0 +1,17 @@
+%T Testing btex
+
+\setupcolors[state=start]
+\usemodule[vim]
+
+\definevimtyping  [RUBY]    [syntax=ruby, cache=force, purge=no]
+
+\starttext
+\startRUBY[numbering=yes]
+# Here's the code:
+ 
+puts "Hello World!" /BTEX\someline[test]/ETEX
+\stopRUBY
+
+Notice that \inline{line}[test] prints to \type{STDOUT}
+\stoptext
+


### PR DESCRIPTION
This is inspired from pull request #30 and #32 by @hernot, which was a follow up to #29.

Request #30 and #32 scan for `\startline`, `\stopline` and `\someline` in the comments and pass them unchanged to context.

I think that instead of writing such code for specific macros, it is better to implement the general purpose escape mechanism of `/BTEX ... /ETEX`, which is the standard mechanism for most typing environments in ConTeXt.

This pull request implements a simpler version of /BTEX ... /ETEX mechanism. We first scan the file for /BTEX ... /ETEX, and store the content of in a dictionary. Then, we remove all the /BTEX .. /ETEX from the file (so that they do not effect syntax highlighting), run the `2context.vim` script and reinsert the content of `/BTEX .. /ETEX` _at the end of_ the original lines.

Note that we do not attempt to reinsert the contents of `/BTEX .. /ETEX` at the correct column. It should be possible to keep track of the column with a little more book-keeping.

