### PR TITLE
first version of xml, xhtml and epub export tagging support

### DIFF
--- a/t-syntax-groups.tex
+++ b/t-syntax-groups.tex
@@ -40,6 +40,193 @@
 \def\definesyntaxgroup
     {\dodoubleargument\syntaxgroup@define}
 
+%% file handle used to create cssfile for each colorscheme defined
+\newwrite \colorscheme@cssout
+
+\startluacode
+    -- helper methods
+    -- TODO most likely to be shipped out to distinct *.lua file in
+    -- production code. Done on advice.
+
+    colorscheme = colorscheme or {} -- namespace handle
+    settings_to_array = utilities.parsers.settings_to_array
+
+    function scalechannel(val)
+        -- converts context rgb and alpha channel values to 
+        -- to css hex codeable values
+        return math.min(math.round(val*255),255)
+    end
+
+    -- map used to translate context transparency mode numbers into corresponding
+    -- css mix-blend-mode strings. Most modes and strings are identical
+    -- some are written with hyphen inbetween. Two seem not to be supported
+    -- they are mapped to the closest looking mode according to figure 1.6 in [1]
+    -- on page 16 and preceeding table on page 15.
+    --
+    -- [1] Hagen Hans, Coloring ConTeXt explaining luatex and mkiv, PRAGMA ADE, 2016
+    --     online: http://www.pragma-ade.com/general/manuals/colors-mkiv.pdf
+    --
+    blendmodemap = {
+         [1] = "normal","multiply","screen","overlay",
+         "luminosity","normal", -- mapped to closest supported by css
+         "color-doge","color-burn","darken","lighten",
+         "difference","exclusion","hue","saturation",
+         "color","luminosity"
+    }
+
+	function colorscheme.cssformatcolor(str,transparency)
+        -- converts colorvalue string and transparencycomponents string
+        -- into proper css RGBA hex color value and mix-blend-mode value
+
+        -- TODO maybe replace access to colorvalue and transparency 
+        --      by access to public luainterface 
+        --      this has to be done by somebody with more indeep luatex mkiv
+        --      and lmtx/lmtx mkiv knowledge respective than me
+
+		local colorvals = {} -- pars colorvalue string to get all components
+
+        -- split colorvalue string
+		for channel in string.gmatch(str,"([^%s]+)") do
+            table.insert(colorvals,tonumber(channel))
+        end
+
+        local alphachannel = {} -- parsed component string if not empty
+
+        -- split transparency string 
+        -- currently is formated as a=<modenumber> st=<opacity value>
+        -- TODO verify that a is mode and st is opacity and not vice versa
+        for value in string.gmatch(transparency,"([^%s=]+)") do
+            table.insert(alphachannel,tonumber(value))
+        end
+        -- select blend mode if alphachannel has at least the four elements
+        -- ['a','<modenumber>','st','<opacity value>']
+        -- directly output css mix-blend-mode attribute string to context
+        -- and convert opacity number to alpha channel hex value
+        if #alphachannel >= 4 and alphachannel[1] == "a" and alphachannel[3] == "st" then
+            context("mix-blend-mode: ",blendmodemap[math.floor(alphachannel[2])])
+            alphavalue = string.format("%02X",scalechannel(alphachannel[4]))
+        end
+ 
+        -- assemble css color attribute value dependent upon color model used to define
+        -- context color. Model can be distinguished by number of entries in colorvals array
+        -- #colorvals == 4 -> CMYK
+        -- #colorvals == 3 -> RGB
+        -- #colorvals == 2 -> ??? TODO how has more knowledge on this context color mode
+        -- #colorvals == 1 -> grey/BW
+        -- #colorvals < 1  -> invalid: black
+        -- #colorvals > 4  -> invalid: black
+        --
+        -- append alphavalue string if not empty and output resulting string to context
+        context("color: ")
+        context.letterhash()
+        if #colorvals == 3 then
+			context("%02X%02X%02X%s;",scalechannel(colorvals[1]),scalechannel(colorvals[2]),scalechannel(colorvals[3]),alphavalue)
+        elseif #colorvals == 4 then
+            brightness = 1-colorvals[4]
+			context("%02X%02X%02X%s;",scalechannel((1-colorvals[1])*brightness),scalechannel((1-colorvals[2])*brightness),scalechannel((1-colorvals[3]) * brightness,alphavalue ))
+        elseif #colorvals == 1 then
+            colorvals[1] = scalechannel(colorvals[1])
+            context("%02X%02X%02X%s;",colorvals[1],colorvals[1],colorvals[1],alphavalue)
+        else
+            context("000000%s",alphavalue)
+        end
+    end
+
+    local reporter = logs.reporter("module","t-vim")
+
+    function verify_css_styles_path(jobname)
+        local exportpath = string.format("%s-export",jobname)
+        if not lfs.isdir(exportpath) then
+            lfs.mkdir(exportpath)
+            if not lfs.isdir(exportpath) then
+                 return "."
+            end
+		end
+        local stylespath = file.join(exportpath,"styles")
+        if not lfs.isdir(stylespath) then
+            lfs.mkdir(stylespath)
+            if not lfs.isdir(stylespath) then
+                 return exportpath
+            end
+		end
+        return stylespath
+    end
+
+    function colorscheme.css_export_path(jobname,name)
+         -- assembles proper path for storing css file for colorsceme 
+         -- TODO likely could also be done in context directly but failed to make it work as expected
+         context(file.join(verify_css_styles_path(jobname),jobname.."-t-syntaxgroup-".. name ..".css"))
+    end
+
+    function colorscheme.append_css_file(l,jobname,name)
+        -- appends colorscheme css file into cssfile export parameter
+        -- this is called when a new vimtyping environment is defined to ensure
+        -- that the exporter consideres the appropriate cssfile for the selected
+        -- colorscheme.
+
+        -- split content of cssfile export parameter into list of individual file names
+        local currentcssfiles = settings_to_array(l,false)
+
+        -- path to css file for colorscheme denoted by name
+        local cssfilepath = jobname.."-t-syntaxgroup-".. name ..".css"
+        if not table.contains(currentcssfiles,cssfilepath) then
+            -- insert colorschem css file into list and output resulting string to
+            -- context
+        	table.insert(currentcssfiles,cssfilepath)
+        	l = table.concat(table.unique(currentcssfiles),", ")
+		end
+        context("%s",l)
+    end
+
+\stopluacode
+
+\def\colorscheme@formatcolor#1#2{\ctxlua{colorscheme.cssformatcolor("#1","#2","\letterhash")}}
+
+\starttexdefinition colorscheme@output_css_yes#1#2#3#4#5 
+    % #1 ... colorscheme name
+    % #2 ... syntaxgroup id
+    % #3 ... \syntaxgroupparameter\c!color
+    % #4 ... \syntaxgroupparameter\c!style
+    % #5 ... \syntaxgroupparameter\c!command
+    % helper method to write css sections for each syntaxgroup defined for 
+    % a specific colorscheme.
+    % exporter generates xml tag based xhtml (postfix: -tag) and html tag based xhtml (postifx: -div)
+    % css file selectors have to be formulated for both formats. to avoid unecessary duplication
+    % both are listed as alternative for ach other. see css spec for details 
+    \immediate\write\colorscheme@cssout{\syntaxhighlighting@id[detail=#1] \syntaxgroup@id[detail=#2], .\syntaxhighlighting@id.#1 .\syntaxgroup@id.#2 \letteropenbrace}
+    \doifsomething{\colorvalue{#3}}{
+         \immediate\write\colorscheme@cssout{\colorscheme@formatcolor{\colorvalue{#3}}{\transparencycomponents{#3}}}
+    }
+    \doifsomething{#4}{
+         % for now just print content of style value and assume css understnads it
+         % TODO better would be if style would be properly parsed and all found attributes set individually or
+         % reassembled to proper css font style string
+         \immediate\write\colorscheme@cssout{    font\lettercolon #4;}
+    }
+    \doifsomething{#5}{%
+         % for now just \underbar and \overbar are considered.
+         \doifelse{#5}{\underbar}{%
+             \immediate\write\colorscheme@cssout{    text-decoration\lettercolon underline;}
+        }{%
+             \doifelse{#5}{\overbar}{%
+                  \immediate\write\colorscheme@cssout{    text-decoration\lettercolon overline;}
+             }{%
+                 % TODO check for other relevant commands or decendants of framed and properly mapp their values
+                 % corresponding css attributes
+             }%
+         }%
+    }
+    \immediate\write\colorscheme@cssout{\letterclosebrace}
+\stoptexdefinition
+
+% if export mode is active output css sections else do nothing 
+\doifmodeelse{*export}{
+   \let\colorscheme@output_css\colorscheme@output_css_yes
+}{
+   \def\colorscheme@output_css#1#2#3#4#5{}
+}
+
+
 \starttexdefinition syntaxgroup@define [#1][#2]
   % #1 list name
   % #2 options
@@ -56,6 +243,7 @@
                                    [\syntaxgroupparameter\c!color]}
              \setupsyntaxgroup[\syntaxgroup@name][\s!parent=\syntaxgroup@namespace,\c!color=\syntaxgroup@namespace-##1-color]
           }
+          \colorscheme@output_css{\colorscheme@name}{##1}{\syntaxgroupparameter\c!color}{\syntaxgroupparameter\c!style}{\syntaxgroupparameter\c!command}
     }
   }{
     \def\syntaxgroup@get_parameters##1%
@@ -67,25 +255,89 @@
                         \c!command=\namedsyntaxgroupparameter{\colorscheme@name#2}\c!command,
                          ]}
 
+        \colorscheme@output_css{\colorscheme@name}{##1}{\syntaxgroupparameter\c!color}{\syntaxgroupparameter\c!style}{\syntaxgroupparameter\c!command}
         % In MkII, \expanded messes up the definition of \currentsyntaxgroup
         \def\currentsyntaxgroup   {\syntaxgroup@name}
     }
   }
-
   \processcommalist[#1]\syntaxgroup@get_parameters
 \stoptexdefinition
 
 \def\startcolorscheme%
     {\dosingleargument\colorscheme@start}
 
+\starttexdefinition colorscheme@output_css_header#1#2#3
+     % first two sections in colorscheme css set display style of 
+     % syntaxhighlightingd and syntaxlinegroup tags therin
+     % for syntaxlinegroup tags in addition the white-space attribute is set
+     % to pre-wrap
+     % TODO switch between pre-wrap and pre dependent uppon 
+     %      \syntaxhighlightingparameter\c!lines and
+     %      \syntaxhighlightingparameter\c!option
+     %
+     \immediate\write\colorscheme@cssout{#1[detail=#2], .#1.#2 \letteropenbrace}
+     \immediate\write\colorscheme@cssout{    display\lettercolon inline;}
+     \immediate\write\colorscheme@cssout{\letterclosebrace} 
+     \immediate\write\colorscheme@cssout{#1[detail=#2] #3, .#1.#2 .#3 \letteropenbrace}
+     \immediate\write\colorscheme@cssout{    display\lettercolon inline;}
+     \immediate\write\colorscheme@cssout{    white-space\lettercolon pre-wrap;}
+     \immediate\write\colorscheme@cssout{\letterclosebrace} 
+\stoptexdefinition
+
 \starttexdefinition colorscheme@start [#1]
      \pushmacro\colorscheme@name
      \setcolorscheme{#1}
      %\setupsyntaxgroup[\c!color=,\c!style=,\c!command=]
+     \doifmode{*export}{
+         % create css file for this colorsceme 
+         \setcssfilename{\jobname}{\colorscheme@name}
+         \writestatus{colorscheme}{cssfile: \colorscheme@css_file}
+         \writestatus{colorscheme}{export: \exportparameter\c!cssfile}
+         \writestatus{colorscheme}{expected: \jobname-templates.css}
+         \writestatus{colorscheme}{title: \exportparameter\c!title}
+         \immediate\openout \colorscheme@cssout \colorscheme@css_file
+         \colorscheme@output_css_header{\syntaxhighlighting@id}{\colorscheme@name}{\syntaxlinegroup@id}\relax
+     }    
 \stoptexdefinition
 
-\def\stopcolorscheme
-    {\popmacro\colorscheme@name}
+\def\stopcolorscheme{\colorscheme@stop}
+
+\starttexdefinition colorscheme@stop
+    \doifmode{*export}{
+        % all syntax groups relevant to this colorscheme are defined close css file
+        \immediate\closeout \colorscheme@cssout
+    }
+    \popmacro\colorscheme@name
+\stoptexdefinition
+
+\def\colorscheme@css_file{}
+\def\setcssfilename#1#2%
+{
+ \edef\colorscheme@css_file{\ctxlua{colorscheme.css_export_path("#1","#2")}}
+}
+
+\starttexdefinition colorscheme@setup_export#1
+    % color scheme is used by a newly define vimtyping environment
+    % ensure that the css file for the selected colorschme is included
+    % into the list of css files considered by the exporter through
+    % the \exportparameter\c!cssfile parameter
+    \writestatus{colorscheme}{setup cssfile}
+    \doifmode{*export}{
+        \def\inject_css_file##1##2{
+            \writestatus{colorscheme}{current: ##1 jobname ##2 scheme {#1}}
+            \edef\extended_css_file_list{\ctxlua{colorscheme.append_css_file("##1","##2","#1")}}
+            \writestatus{colorscheme}{extended css: \extended_css_file_list}
+            \setupexport[cssfile={\extended_css_file_list}]
+            % exporter works a bit differnt it has its' own hardcoded setup routine
+            % which is called on every \startdocument \starttext \startproject etc. call
+            % the nasty thing about is that \dosynchronizeexport empties the \currentexport
+            % macro therefor a new call to \setupexport has not effect unless \dosynchronizeexport
+            % is called immediately afterwards to update current setup stored internally in lua only
+            \dosynchronizeexport
+        }
+        \inject_css_file{\exportparameter\c!cssfile}{\jobname}
+    }
+\stoptexdefinition
 
 \def\setcolorscheme#1%
     {\edef\colorscheme@name{#1}}

--- a/t-syntax-highlight.mkiv
+++ b/t-syntax-highlight.mkiv
@@ -60,8 +60,12 @@
           ]}%
 \to\everysetupsyntaxhighlighting
 
-\def\syntaxhighlighting@id {syntaxhighlighting}
+\def\syntaxhighlighting@id{syntaxhighlighting}
 \edef\t!syntaxhighlighting {\syntaxhighlighting@id}
+\def\syntaxlinegroup@id{syntaxlinegroup}
+\edef\t!syntaxlinegroup{\syntaxlinegroup@id}
+\def\syntaxlinegroup@force_break{break}
+\edef\t!break{\syntaxlinegroup@force_break}
 
 %D Helper macro
 
@@ -96,7 +100,7 @@
   \doifnotinset{\externalfilterparameter\c!option}{\v!hyphenated}
       {\language\minusone}%
 
-  \def\obeyedline{\strut\par}
+  \def\obeyedline{\strut\par\writestatus{vimtyping}{obyeying new line}}
   \setcatcodetable\externalfilter@minimal_catcodes%
   \letcharcode\endoflineasciicode\obeyedline
   \letcharcode\spaceasciicode\obeyedspace
@@ -106,12 +110,12 @@
 
 \starttexdefinition syntaxhighlighting@read_command #1
     \syntaxhighlighting@linenumbering_start
-    \ReadFile{#1}
+   	\ReadFile{#1}
     \syntaxhighlighting@linenumbering_stop
 \stoptexdefinition
 
 \starttexdefinition syntaxhighlighting@linenumbering_start
-   \doifinset{\externalfilterparameter\c!numbering}\syntaxhighlighting@yes
+   \doifinsetelse{\externalfilterparameter\c!numbering}\syntaxhighlighting@yes
        {\let\SYNBOL=\syntaxhighlighting_begin_number_lines
         \let\SYNEOL=\syntaxhighlighting_end_number_lines
         \startlinenumbering
@@ -122,6 +126,9 @@
                 \c!step=\externalfilterparameter{\c!number\c!step},
              \c!continue=\externalfilterparameter{\c!number\c!continue},
           ]}
+       {\let\SYNBOL=\syntaxhighlighting_begin_lines
+        \let\SYNEOL=\syntaxhighlighting_end_lines
+       }
    \dostarttagged\t!syntaxhighlighting\colorscheme@name
 \stoptexdefinition
 
@@ -134,14 +141,35 @@
 \newcount\nofsyntaxhighlightinglines
 
 \starttexdefinition syntaxhighlighting_begin_number_lines
+  \writestatus{vimtyping}{in begin number}
   \global\advance\nofsyntaxhighlightinglines\plusone
   \attribute\verbatimlineattribute\nofsyntaxhighlightinglines
+  \syntaxhighlighting_begin_lines
 \stoptexdefinition
 
 \starttexdefinition syntaxhighlighting_end_number_lines
+   \syntaxhighlighting_end_lines
    \attribute\verbatimlineattribute\attributeunsetvalue
+   \writestatus{vimtyping}{in end number}
 \stoptexdefinition
 
+\starttexdefinition syntaxhighlighting_begin_lines
+  \writestatus{vimtyping}{in begin line}
+  \noindent\the\everyline %
+  \dostarttagged\t!syntaxlinegroup\empty%
+\stoptexdefinition
+
+\starttexdefinition syntaxhighlighting_end_lines
+  \writestatus{vimtyping}{in end line}
+  \dostoptagged
+  \writestatus{vimtyping}{before break}
+  \dostarttagged\t!break\empty
+  {  }
+  \strut %
+  \relax %
+  \dostoptagged
+  \writestatus{vimtypeing}{after break}
+\stoptexdefinition
 
 \setupsyntaxhighlighting
   [\c!tab=4,
@@ -217,7 +245,17 @@
 \installspacemethod {\????syntaxhighlighting\v!off}
   {\unexpanded\def\obeyedspace
       {\mathortext\normalspace
-          {\syntaxhighlighting@split\interwordspace\relax}}%
+          %% had to replace by \asciispacechar as \interwordspace
+          %% seems to be allways collapsed by exporter int one single
+          %% space in resulting xhtml and xml files
+          %% TODO possibly switch between the two version
+          %%      using \doifmodeelse or find way to properly
+          %%      setup \interwordspace such that it is not
+          %%      collapsed in single space by exporter
+          %{\syntaxhighlighting@split\interwordspace\relax}}%
+          {\syntaxhighlighting@split\zeropoint\relax
+           \hbox{\asciispacechar}%
+           \syntaxhighlighting@split\zeropoint\relax}}
    \letcharcode\spaceasciicode\obeyedspace}
 
 % Default

--- a/t-vim.tex
+++ b/t-vim.tex
@@ -38,6 +38,7 @@
 
     \definesyntaxhighlighting[#1][\s!parent=\vimtyping@namespace#1]
     \setupsyntaxhighlighting [#1][#2]
+    \colorscheme@setup_export{\syntaxhighlightingparameter\c!alternative}
 
 
     \setvalue{\e!start raw#1}{\bgroup\obeylines\dodoubleargument\vimtyping@start_raw[#1]}

--- a/tests/vim/35-SYNBOL-SYNEOL-tagging.tex
+++ b/tests/vim/35-SYNBOL-SYNEOL-tagging.tex
@@ -1,0 +1,13 @@
+\usemodule[amsl]
+\usemodule[vim]
+\definevimtyping[Python][syntax=python,tab=4,numbering=no]
+\starttext
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
+\startPython
+a=12
+def hello_world(hello)
+	print("simon says: {}".format(hello))
+hallo_welt("how do youdo")
+\stopPython
+\stoptext
+

--- a/tests/vim/35-SYNBOL-SYNEOL-tagging.tex
+++ b/tests/vim/35-SYNBOL-SYNEOL-tagging.tex
@@ -1,13 +1,12 @@
-\usemodule[amsl]
 \usemodule[vim]
-\definevimtyping[Python][syntax=python,tab=4,numbering=no]
+\definevimtyping[PYTHON][syntax=python,tab=4,numbering=no]
 \starttext
-This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
-\startPython
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any side effects
+\startPYTHON
 a=12
 def hello_world(hello)
 	print("simon says: {}".format(hello))
-hallo_welt("how do youdo")
-\stopPython
+hallo_welt("how do you do")
+\stopPYTHON
 \stoptext
 

--- a/tests/vim/36-SYNBOL-SYNEOL-ln-tagging.tex
+++ b/tests/vim/36-SYNBOL-SYNEOL-ln-tagging.tex
@@ -1,0 +1,13 @@
+\usemodule[amsl]
+\usemodule[vim]
+\definevimtyping[Python][syntax=python,tab=4,numbering=yes]
+\starttext
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects when linenumbering is on
+\startPython
+a=12
+def hello_world(hello)
+	print("simon says: {}".format(hello))
+hallo_welt("how do youdo")
+\stopPython
+\stoptext
+

--- a/tests/vim/36-SYNBOL-SYNEOL-ln-tagging.tex
+++ b/tests/vim/36-SYNBOL-SYNEOL-ln-tagging.tex
@@ -1,13 +1,12 @@
-\usemodule[amsl]
 \usemodule[vim]
-\definevimtyping[Python][syntax=python,tab=4,numbering=yes]
+\definevimtyping[PYTHON][syntax=python,tab=4,numbering=yes]
 \starttext
-This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects when linenumbering is on
-\startPython
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any side effects when linenumbering is on
+\startPYTHON
 a=12
 def hello_world(hello)
 	print("simon says: {}".format(hello))
-hallo_welt("how do youdo")
-\stopPython
+hallo_welt("how do you do")
+\stopPYTHON
 \stoptext
 

--- a/tests/vim/37-SYNBOL-SYNEOL-tagging-tagging-export.tex
+++ b/tests/vim/37-SYNBOL-SYNEOL-tagging-tagging-export.tex
@@ -1,23 +1,18 @@
-\setupbackend[
-export=yes,
-xhtml=yes
-]
-\setupexport[
-title={\type{SYNBOL}, \type{SYNEOL} tagging test},
-subtitle={},
-author={J.R.C.H.}
-]
-\usemodule[amsl]
+\setupbackend
+  [
+    export=yes,
+    xhtml=yes
+  ]
 \usemodule[vim]
-\definevimtyping[Python][syntax=python,tab=4,numbering=no]
+\definevimtyping[PYTHON][syntax=python,tab=4,numbering=no]
 \starttext
 This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
 when export is set to XML
-\startPython
+\startPYTHON
 a=12
 def hello_world(hello)
     print("simon says: {}".format(hello))
 hallo_welt("how do youdo")
-\stopPython
+\stopPYTHON
 \stoptext
 

--- a/tests/vim/37-SYNBOL-SYNEOL-tagging-tagging-export.tex
+++ b/tests/vim/37-SYNBOL-SYNEOL-tagging-tagging-export.tex
@@ -1,0 +1,23 @@
+\setupbackend[
+export=yes,
+xhtml=yes
+]
+\setupexport[
+title={\type{SYNBOL}, \type{SYNEOL} tagging test},
+subtitle={},
+author={J.R.C.H.}
+]
+\usemodule[amsl]
+\usemodule[vim]
+\definevimtyping[Python][syntax=python,tab=4,numbering=no]
+\starttext
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
+when export is set to XML
+\startPython
+a=12
+def hello_world(hello)
+    print("simon says: {}".format(hello))
+hallo_welt("how do youdo")
+\stopPython
+\stoptext
+

--- a/tests/vim/38-SYNBOL-SYNEOL-ln-tagging-export.tex
+++ b/tests/vim/38-SYNBOL-SYNEOL-ln-tagging-export.tex
@@ -1,28 +1,22 @@
-\setupbackend[
-export=yes,
-xhtml=yes
-]
-\setupexport[
-title={\type{SYNBOL}, \type{SYNEOL} tagging test},
-subtitle={},
-author={J.R.C.H.}%,
-%cssfile=38-SYNBOL-SYNEOL-ln-tagging-export-templates.css%
-]
-\usemodule[amsl]
+\setupbackend
+  [
+    export=yes,
+    xhtml=yes
+  ]
 \usemodule[vim]
 \writestatus{main}{we define Python}
-\definevimtyping[Python][syntax=python,tab=4,numbering=yes]
+\definevimtyping[PYTHON][syntax=python,tab=4,numbering=yes,numberlocation=right]
 \traceexternalfilters
 \writestatus{main}{we start now}
 \starttext
 %\exportparameter\c!cssfile
-This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any side effects
 when export is set to XML
-\startPython
+\startPYTHON
 a=12
 def hello_world(hello)
     print("simon says:    {}".format(hello))
-hallo_welt("how do youdo")
-\stopPython
+hallo_welt("how do you do")
+\stopPYTHON
 \stoptext
 

--- a/tests/vim/38-SYNBOL-SYNEOL-ln-tagging-export.tex
+++ b/tests/vim/38-SYNBOL-SYNEOL-ln-tagging-export.tex
@@ -1,0 +1,28 @@
+\setupbackend[
+export=yes,
+xhtml=yes
+]
+\setupexport[
+title={\type{SYNBOL}, \type{SYNEOL} tagging test},
+subtitle={},
+author={J.R.C.H.}%,
+%cssfile=38-SYNBOL-SYNEOL-ln-tagging-export-templates.css%
+]
+\usemodule[amsl]
+\usemodule[vim]
+\writestatus{main}{we define Python}
+\definevimtyping[Python][syntax=python,tab=4,numbering=yes]
+\traceexternalfilters
+\writestatus{main}{we start now}
+\starttext
+%\exportparameter\c!cssfile
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
+when export is set to XML
+\startPython
+a=12
+def hello_world(hello)
+    print("simon says:    {}".format(hello))
+hallo_welt("how do youdo")
+\stopPython
+\stoptext
+

--- a/tests/vim/39-SYNBOL-SYNEOL-tagging-export-float.tex
+++ b/tests/vim/39-SYNBOL-SYNEOL-tagging-export-float.tex
@@ -1,0 +1,31 @@
+\setupbackend[
+export=yes,
+xhtml=yes
+]
+\setupexport[
+title={\type{SYNBOL}, \type{SYNEOL} tagging test},
+subtitle={},
+author={J.R.C.H.}
+]
+\usemodule[amsl]
+\usemodule[vim]
+\setupfloat[Beispiel][width=.8\textwidth,location=middle,spacebefore=small,spaceafter=small]
+\setupcaption[Beispiel][] 
+\defineframedtext[PythonFramed][align=middle,frame=none,width=.9\textwidth]
+\definevimtyping[Python][syntax=python,tab=4,numbering=no,lines=split,option={packed,hyphenated},before={\startPythonFramed\switchtobodyfont[10pt]},after=\stopPythonFramed]
+\starttext
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
+when export is set to XML
+\placefloat[]
+[code:complex_test]
+{this is a more realistic example on how vimtyping may be used}
+{
+\startPython
+a=12
+def hello_world(hello)
+    print("simon says: {}".format(hello))
+hallo_welt("how do youdo")
+\stopPython
+}
+\stoptext
+

--- a/tests/vim/39-SYNBOL-SYNEOL-tagging-export-float.tex
+++ b/tests/vim/39-SYNBOL-SYNEOL-tagging-export-float.tex
@@ -1,18 +1,13 @@
-\setupbackend[
-export=yes,
-xhtml=yes
-]
-\setupexport[
-title={\type{SYNBOL}, \type{SYNEOL} tagging test},
-subtitle={},
-author={J.R.C.H.}
-]
-\usemodule[amsl]
+\setupbackend
+  [
+    export=yes,
+    xhtml=yes
+  ]
 \usemodule[vim]
 \setupfloat[Beispiel][width=.8\textwidth,location=middle,spacebefore=small,spaceafter=small]
 \setupcaption[Beispiel][] 
 \defineframedtext[PythonFramed][align=middle,frame=none,width=.9\textwidth]
-\definevimtyping[Python][syntax=python,tab=4,numbering=no,lines=split,option={packed,hyphenated},before={\startPythonFramed\switchtobodyfont[10pt]},after=\stopPythonFramed]
+\definevimtyping[PYTHON][syntax=python,tab=4,numbering=no,lines=split,option={packed,hyphenated},before={\startPythonFramed\switchtobodyfont[10pt]},after=\stopPythonFramed]
 \starttext
 This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
 when export is set to XML
@@ -20,12 +15,12 @@ when export is set to XML
 [code:complex_test]
 {this is a more realistic example on how vimtyping may be used}
 {
-\startPython
+\startPYTHON
 a=12
 def hello_world(hello)
     print("simon says: {}".format(hello))
 hallo_welt("how do youdo")
-\stopPython
+\stopPYTHON
 }
 \stoptext
 

--- a/tests/vim/40-SYNBOL-SYNEOL-ln-tagging-export-float.tex
+++ b/tests/vim/40-SYNBOL-SYNEOL-ln-tagging-export-float.tex
@@ -1,0 +1,37 @@
+\setupbackend[
+export=yes,
+xhtml=yes
+]
+\setupexport[
+title={\type{SYNBOL}, \type{SYNEOL} tagging test},
+subtitle={},
+author={J.R.C.H.}%,
+%cssfile=38-SYNBOL-SYNEOL-ln-tagging-export-templates.css%
+]
+\usemodule[amsl]
+\usemodule[vim]
+\writestatus{main}{we define Python}
+\definefloat[Beispiel]
+\setupfloat[Beispiel][width=.8\textwidth,location=middle,spacebefore=small,spaceafter=small]
+\setupcaption[Beispiel][] 
+\defineframedtext[PythonFramed][align=middle,frame=none,width=.9\textwidth]
+\definevimtyping[Python][syntax=python,tab=4,numbering=yes,lines=split,option={packed,hyphenated},before={\startPythonFramed\switchtobodyfont[10pt]},after=\stopPythonFramed]
+\traceexternalfilters
+\writestatus{main}{we start now}
+\starttext
+%\exportparameter\c!cssfile
+This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
+when export is set to XML
+\placeBeispiel[]
+[code:complex_number_test]
+{this is a more realistic example on how vimtyping with active linenumbers may be used}
+{%
+\startPython
+a=12
+def hello_world(hello)
+    print("simon says:    {}".format(hello))
+hallo_welt("how do youdo")
+\stopPython%
+}
+\stoptext
+

--- a/tests/vim/40-SYNBOL-SYNEOL-ln-tagging-export-float.tex
+++ b/tests/vim/40-SYNBOL-SYNEOL-ln-tagging-export-float.tex
@@ -1,37 +1,30 @@
-\setupbackend[
-export=yes,
-xhtml=yes
-]
-\setupexport[
-title={\type{SYNBOL}, \type{SYNEOL} tagging test},
-subtitle={},
-author={J.R.C.H.}%,
-%cssfile=38-SYNBOL-SYNEOL-ln-tagging-export-templates.css%
-]
-\usemodule[amsl]
+\setupbackend
+  [
+    export=yes,
+    xhtml=yes
+  ]
 \usemodule[vim]
 \writestatus{main}{we define Python}
 \definefloat[Beispiel]
 \setupfloat[Beispiel][width=.8\textwidth,location=middle,spacebefore=small,spaceafter=small]
 \setupcaption[Beispiel][] 
 \defineframedtext[PythonFramed][align=middle,frame=none,width=.9\textwidth]
-\definevimtyping[Python][syntax=python,tab=4,numbering=yes,lines=split,option={packed,hyphenated},before={\startPythonFramed\switchtobodyfont[10pt]},after=\stopPythonFramed]
+\definevimtyping[PYTHON][syntax=python,tab=4,numbering=yes,numberlocation=left,lines=split,option={packed,hyphenated},before={\startPythonFramed\switchtobodyfont[10pt]},after=\stopPythonFramed]
 \traceexternalfilters
 \writestatus{main}{we start now}
 \starttext
 %\exportparameter\c!cssfile
 This is a little test whether modifcation in \type{\SYNBOL} and \type{\SYNEOL} have any sideeffects
 when export is set to XML
-\placeBeispiel[]
+\startplaceBeispiel[]
 [code:complex_number_test]
 {this is a more realistic example on how vimtyping with active linenumbers may be used}
-{%
-\startPython
+\startPYTHON
 a=12
 def hello_world(hello)
     print("simon says:    {}".format(hello))
 hallo_welt("how do youdo")
-\stopPython%
-}
+\stopPYTHON%
+\stopplaceBeispiel
 \stoptext
 


### PR DESCRIPTION
late happy easter

Managed to add taggs and css files to support xml/xhtml export and epub generation

This is a very first version. But line numbering will still need some indeep attention. currently only tested with number location left. Which works outside floats but already beraks inside (*)
And i do expect even wors breaking for any other remaining placement (*)

(*) line numbers are not placed immediately infront or after <synaxlinegroup> trags but immediately after float tag and before end float tag.

But for some advice it should be fair and OK enough.