### PR TITLE
css update to ensure environment independent line wrapping

### DIFF
--- a/tests/vim/43-export-float.tex
+++ b/tests/vim/43-export-float.tex
@@ -1,6 +1,7 @@
 \setupbackend[export=yes]
 
 \usemodule[vim]
+\setupexport[cssfile=\vimtypingcssfile]
 
 \definevimtyping[PYTHON][syntax=python]
 

--- a/vimtyping-default.css
+++ b/vimtyping-default.css
@@ -36,6 +36,13 @@ inlinevimtyping verbatimline,
     white-space:pre-wrap;
 }
 
+floatcontent vimtyping verbatimline,
+.floatcontent .vimtyping .verbatimline
+{
+    display:block;
+    white-space:pre-wrap;
+}
+
 vimtyping syntaxgroup,
 inlinevimtyping syntaxgroup,
 .vimtyping .syntaxgroup,


### PR DESCRIPTION
this is just a small side in the issue related i'm already persuing for some time with the help of hans and others. Details see #64 .
In preparation thereof i rerun the export tests and figured that line wrapping is left at where our last attempts have stopped. I gave it again a try on Firefox (99.0) and Google Chrome (Chromium  100.0.4896.60) on Linux Mint 20 and figured what to do to ensure linewrapping is proper when vimtyping environment is used standalone and withing floating environment.
The result is this pullrequest

**Note:**
Just noticed that update of context did not yield the latest version as expected but is stuck in 2020 version. Will update and rerun again with latest context. At least `context --version` tells me the following eventhough i rerun first-setup.sh

```
mtx-context     | ConTeXt Process Management 1.03
mtx-context     |
mtx-context     | main context file: /home/nother/bin/context/tex/texmf-context/tex/context/base/mkiv/context.mkiv
mtx-context     | current version: 2020.01.30 14:13
mtx-context     | main context file: /home/nother/bin/context/tex/texmf-context/tex/context/base/mkiv/context.mkxl
mtx-context     | current version: 2020.01.30 14:13
```

**Edit**
Guess i have to also get the latest context standalone (see below) for work before as with it and the css fix in this pullrequest not just line wrapping is finally at least on the named browsers  proper but also line numbers seem to be back in pdf and export.. Keep you posted on this and the other stuff

```
mtx-context     | ConTeXt Process Management 1.04
mtx-context     |
mtx-context     | main context file: /home/nother/bin/context/tex/texmf-context/tex/context/base/mkiv/context.mkiv
mtx-context     | current version: 2022.04.15 20:13
mtx-context     | main context file: /home/nother/bin/context/tex/texmf-context/tex/context/base/mkxl/context.mkxl
mtx-context     | current version: 2022.04.15 20:13
```
